### PR TITLE
Fix for mixedup variable position when both variable formats present in the message and showing ${} during edit

### DIFF
--- a/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/status/util/AutocompleteField.kt
+++ b/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/status/util/AutocompleteField.kt
@@ -66,7 +66,7 @@ class AutocompleteField(
     var addOnSuggestionDoubleClick: Boolean = true
     var placeHolderTextColor: Color? = null
     var canShowSaveButton = true
-    var patternPair: Pair<Pattern?, Pattern?> = Pair.empty();
+    var variablePattern: Pattern?
 
     val matchAndApplyStyle = { m: Matcher ->
         while (m.find()) {
@@ -116,7 +116,7 @@ class AutocompleteField(
         document.addDocumentListener(this)
         addKeyListener(this)
 
-        patternPair = VariableParser.createPattern(allLookup.map { a->a.getText().substring(1)})
+        variablePattern = VariableParser.createPattern(allLookup.map { a->a.getText().substring(1)})
 
         document.putProperty("filterNewlines", true)
 
@@ -185,7 +185,7 @@ class AutocompleteField(
             true
         )
 
-        VariableParser.matchVariables(patternPair, text, matchAndApplyStyle)
+        VariableParser.matchVariables(variablePattern, text, matchAndApplyStyle)
     }
 
     private fun addNumberStyle(pn: JTextPane) {

--- a/plugin/src/test/kotlin/spp/jetbrains/sourcemarker/service/log/VariableParserTest.kt
+++ b/plugin/src/test/kotlin/spp/jetbrains/sourcemarker/service/log/VariableParserTest.kt
@@ -25,38 +25,49 @@ class VariableParserTest {
     @Test
     fun extractVariablesPattern1() {
         val input = "hello\$tt \$tthello \${tt}\$tt"
-        val patternPair = VariableParser.createPattern(listOf("tt", "deleteDate", "executorService"))
-        val resp = VariableParser.extractVariables(patternPair, input)
+        val variablePattern = VariableParser.createPattern(listOf("tt", "deleteDate", "executorService"))
+        val resp = VariableParser.extractVariables(variablePattern, input)
 
         assertEquals(3, resp.second.size)
-        assertEquals("hello{} \$tthello {}{}", resp.first)
+        assertEquals("hello{} \$tthello []{}", resp.first)
     }
 
     @Test
     fun extractVariablesPattern2() {
         val input = "\$tt \$deleteDate \${tt}\${deleteDate}\$tt"
-        val patternPair = VariableParser.createPattern(listOf("tt", "deleteDate", "executorService"))
-        val resp = VariableParser.extractVariables(patternPair, input)
+        val variablePattern = VariableParser.createPattern(listOf("tt", "deleteDate", "executorService"))
+        val resp = VariableParser.extractVariables(variablePattern, input)
 
         assertEquals(5, resp.second.size)
-        assertEquals("{} {} {}{}{}", resp.first)
+        assertEquals("{} {} [][]{}", resp.first)
     }
 
     @Test
     fun extractVariablesPattern3() {
         val input = "hello\$user \$deleteDatebut not\${user}working\${deleteDate}\$user"
-        val patternPair = VariableParser.createPattern(listOf("user", "deleteDate", "executorService"))
-        val resp = VariableParser.extractVariables(patternPair, input)
+        val variablePattern = VariableParser.createPattern(listOf("user", "deleteDate", "executorService"))
+        val resp = VariableParser.extractVariables(variablePattern, input)
 
         assertEquals(4, resp.second.size)
-        assertEquals("hello{} \$deleteDatebut not{}working{}{}", resp.first)
+        assertEquals("hello{} \$deleteDatebut not[]working[]{}", resp.first)
+    }
+
+    @Test
+    fun testVariableOrder() {
+        val input = "\${i}hi\$date"
+        val variablePattern = VariableParser.createPattern(listOf("i", "deleteDate", "date"))
+        val resp = VariableParser.extractVariables(variablePattern, input)
+
+        assertEquals(2, resp.second.size)
+        assertEquals("[]hi{}", resp.first)
+        assertEquals(listOf("\$i", "\$date"), resp.second)
     }
 
     @Test
     fun extractNoVariables() {
         val input = "hello\$user \$deleteDatebut not\${user}working\${deleteDate}\$user"
-        val patternPair = VariableParser.createPattern(emptyList())
-        val resp = VariableParser.extractVariables(patternPair, input)
+        val variablePattern = VariableParser.createPattern(emptyList())
+        val resp = VariableParser.extractVariables(variablePattern, input)
 
         assertEquals(0, resp.second.size)
         assertEquals(input, resp.first)


### PR DESCRIPTION
Fix includes 
1. Using single pattern for both $var and ${var} formats - this fixes the variable position issue.
2. Using a different placeholder '[]' for variable pattern ${} 