### PR TITLE
[Bugfix] Issue 1041 - Displaying live charts over 4 hours fails

### DIFF
--- a/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindow.kt
+++ b/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindow.kt
@@ -68,7 +68,7 @@ class LiveViewChartWindow(
     private var reservoirSize = 5
     private val keepTimeSize: Int
         get() = step.milliseconds * reservoirSize
-    private var xStepSize = step.milliseconds
+    private var xStepSize: Long = (step.milliseconds).toLong()
     private val metricType = MetricType(liveView.viewConfig.viewMetrics.first())
     private var chartColor = defaultChartColor(metricType)
     private val timeFormat = SimpleDateFormat("h:mm a")
@@ -99,6 +99,12 @@ class LiveViewChartWindow(
         val stop = Instant.now()
         val start = stop.truncatedTo(ChronoUnit.SECONDS)
             .minusSeconds(60 + (getHistoricalMinutes() * 60).toLong())
+        log.info(">>>>>>>>>>>>>>>>>>>>")
+        log.info(">>>>>>>>>>>>>>>>>>>> step (getHistoricalData) = $step")
+        log.info(">>>>>>>>>>>>>>>>>>>> start (getHistoricalData) = $start")
+        log.info(">>>>>>>>>>>>>>>>>>>> stop (getHistoricalData) = $stop")
+        log.info(">>>>>>>>>>>>>>>>>>>> labels (getHistoricalData) = $labels")
+        log.info(">>>>>>>>>>>>>>>>>>>>")
         viewService.getHistoricalMetrics(
             liveView.entityIds.toList(),
             liveView.viewConfig.viewMetrics,
@@ -144,7 +150,18 @@ class LiveViewChartWindow(
         reservoirSize = historicalMinutes
         histogram = Histogram(SlidingWindowReservoir(histogramSize))
         //chart.clear() //todo: possible memory leak
-        xStepSize = step.milliseconds * reservoirSize
+        log.info(">>>>>>>>>>>>>>>>>>>>")
+        log.info(">>>>>>>>>> before step.seconds = ${step.seconds}")
+        log.info(">>>>>>>>>> before step.milliseconds = ${step.milliseconds}")
+        log.info(">>>>>>>>>> before reservoirSize = $reservoirSize")
+        log.info(">>>>>>>>>> before xStepSize = $xStepSize")
+        xStepSize = (step.milliseconds).toLong() * reservoirSize
+        log.info(">>>>>>>>>>>>>>>>>>>>")
+        log.info(">>>>>>>>>> after step.seconds = ${step.seconds}")
+        log.info(">>>>>>>>>> after step.milliseconds = ${step.milliseconds}")
+        log.info(">>>>>>>>>> after reservoirSize = $reservoirSize")
+        log.info(">>>>>>>>>> after xStepSize = $xStepSize")
+        log.info(">>>>>>>>>>>>>>>>>>>>")
 
         getHistoricalData()
     }

--- a/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindow.kt
+++ b/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindow.kt
@@ -67,7 +67,7 @@ class LiveViewChartWindow(
     private var step = MetricStep.MINUTE
     private var reservoirSize = 5
     private val keepTimeSize: Long
-        get() = step.milliseconds.toLong() * reservoirSize
+        get() = step.milliseconds.toLong() * timeSizeMultiplier()
     private var xStepSize: Long = (step.milliseconds).toLong()
     private val metricType = MetricType(liveView.viewConfig.viewMetrics.first())
     private var chartColor = defaultChartColor(metricType)
@@ -264,6 +264,15 @@ class LiveViewChartWindow(
             left = 40
             bottom = 25
             right = 40
+        }
+    }
+
+    private fun timeSizeMultiplier(): Int {
+        return when (step) {
+            MetricStep.SECOND -> reservoirSize*60
+            MetricStep.MINUTE -> reservoirSize
+            MetricStep.HOUR -> reservoirSize/60
+            MetricStep.DAY -> reservoirSize/(60*24)
         }
     }
 

--- a/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindow.kt
+++ b/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindow.kt
@@ -66,8 +66,8 @@ class LiveViewChartWindow(
     private var consumer: MessageConsumer<JsonObject>? = null
     private var step = MetricStep.MINUTE
     private var reservoirSize = 5
-    private val keepTimeSize: Int
-        get() = step.milliseconds * reservoirSize
+    private val keepTimeSize: Long
+        get() = step.milliseconds.toLong() * reservoirSize
     private var xStepSize: Long = (step.milliseconds).toLong()
     private val metricType = MetricType(liveView.viewConfig.viewMetrics.first())
     private var chartColor = defaultChartColor(metricType)
@@ -99,12 +99,6 @@ class LiveViewChartWindow(
         val stop = Instant.now()
         val start = stop.truncatedTo(ChronoUnit.SECONDS)
             .minusSeconds(60 + (getHistoricalMinutes() * 60).toLong())
-        log.info(">>>>>>>>>>>>>>>>>>>>")
-        log.info(">>>>>>>>>>>>>>>>>>>> step (getHistoricalData) = $step")
-        log.info(">>>>>>>>>>>>>>>>>>>> start (getHistoricalData) = $start")
-        log.info(">>>>>>>>>>>>>>>>>>>> stop (getHistoricalData) = $stop")
-        log.info(">>>>>>>>>>>>>>>>>>>> labels (getHistoricalData) = $labels")
-        log.info(">>>>>>>>>>>>>>>>>>>>")
         viewService.getHistoricalMetrics(
             liveView.entityIds.toList(),
             liveView.viewConfig.viewMetrics,
@@ -150,18 +144,7 @@ class LiveViewChartWindow(
         reservoirSize = historicalMinutes
         histogram = Histogram(SlidingWindowReservoir(histogramSize))
         //chart.clear() //todo: possible memory leak
-        log.info(">>>>>>>>>>>>>>>>>>>>")
-        log.info(">>>>>>>>>> before step.seconds = ${step.seconds}")
-        log.info(">>>>>>>>>> before step.milliseconds = ${step.milliseconds}")
-        log.info(">>>>>>>>>> before reservoirSize = $reservoirSize")
-        log.info(">>>>>>>>>> before xStepSize = $xStepSize")
         xStepSize = (step.milliseconds).toLong() * reservoirSize
-        log.info(">>>>>>>>>>>>>>>>>>>>")
-        log.info(">>>>>>>>>> after step.seconds = ${step.seconds}")
-        log.info(">>>>>>>>>> after step.milliseconds = ${step.milliseconds}")
-        log.info(">>>>>>>>>> after reservoirSize = $reservoirSize")
-        log.info(">>>>>>>>>> after xStepSize = $xStepSize")
-        log.info(">>>>>>>>>>>>>>>>>>>>")
 
         getHistoricalData()
     }

--- a/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindowImpl.kt
+++ b/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindowImpl.kt
@@ -275,10 +275,10 @@ class LiveViewChartWindowImpl(
 
     private fun timeSizeMultiplier(): Int {
         return when (step) {
-            MetricStep.SECOND -> reservoirSize*60
+            MetricStep.SECOND -> reservoirSize * 60
             MetricStep.MINUTE -> reservoirSize
-            MetricStep.HOUR -> reservoirSize/60
-            MetricStep.DAY -> reservoirSize/(60*24)
+            MetricStep.HOUR -> reservoirSize / 60
+            MetricStep.DAY -> reservoirSize / (60 * 24)
         }
     }
 

--- a/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindowImpl.kt
+++ b/plugin/src/main/kotlin/spp/jetbrains/sourcemarker/view/window/LiveViewChartWindowImpl.kt
@@ -99,25 +99,20 @@ class LiveViewChartWindowImpl(
         val stop = Instant.now()
         val start = stop.truncatedTo(ChronoUnit.SECONDS)
             .minusSeconds(60 + (getHistoricalMinutes() * 60).toLong())
-        viewService.clearLiveViews()
-            .onSuccess {
-                viewService.getHistoricalMetrics(
-                    liveView.entityIds.toList(),
-                    liveView.viewConfig.viewMetrics,
-                    step, start, stop, labels
-                ).onSuccess {
-                    for (i in 0 until it.data.size()) {
-                        val stepBucket =
-                            step.bucketFormatter.format(start.plusSeconds((step.seconds * i).toLong())).toLong()
-                        val metricData = it.data.getJsonObject(i)
-                        addMetric(metricData.put("timeBucket", stepBucket))
-                    }
-                }.onFailure {
-                    log.error("Failed to get historical metrics", it)
-                }
-            }.onFailure {
-                log.error("Failed to clear live views", it)
+        viewService.getHistoricalMetrics(
+            liveView.entityIds.toList(),
+            liveView.viewConfig.viewMetrics,
+            step, start, stop, labels
+        ).onSuccess {
+            for (i in 0 until it.data.size()) {
+                val stepBucket =
+                    step.bucketFormatter.format(start.plusSeconds((step.seconds * i).toLong())).toLong()
+                val metricData = it.data.getJsonObject(i)
+                addMetric(metricData.put("timeBucket", stepBucket))
             }
+        }.onFailure {
+            log.error("Failed to get historical metrics", it)
+        }
     }
 
     override fun pause() {


### PR DESCRIPTION

https://github.com/sourceplusplus/sourceplusplus/issues/1041

There were overflows when `reservoirSize` = 720

![image](https://github.com/sourceplusplus/interface-jetbrains/assets/29477940/127115be-b9e3-4b8d-8208-9c972c824556)

This fixes them:

![image](https://github.com/sourceplusplus/interface-jetbrains/assets/29477940/e96eb871-9a21-494e-a8ce-41e061e42b45)

![image](https://github.com/sourceplusplus/interface-jetbrains/assets/29477940/c32e4d2d-d065-4120-9035-e8f576960a53)